### PR TITLE
Use array structure with deterministic order to fix flaky test in MarshallableTest.java

### DIFF
--- a/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
+++ b/src/test/java/net/openhft/chronicle/wire/MarshallableTest.java
@@ -147,6 +147,7 @@ public class MarshallableTest extends WireTestCommon {
     @Test
     public void testReset() {
         MyTypes mt = new MyTypes()
+                .text("text")
                 .flag(true)
                 .b((byte) 1)
                 .s((short) 2)
@@ -154,31 +155,13 @@ public class MarshallableTest extends WireTestCommon {
                 .i(4)
                 .f(5)
                 .d(6)
-                .l(7)
-                .text("text");
-        assertEquals("!net.openhft.chronicle.wire.MyTypes {\n" +
-                "  text: text,\n" +
-                "  flag: true,\n" +
-                "  b: 1,\n" +
-                "  s: 2,\n" +
-                "  ch: \"3\",\n" +
-                "  i: 4,\n" +
-                "  f: 5.0,\n" +
-                "  d: 6.0,\n" +
-                "  l: 7\n" +
-                "}\n", mt.toString());
+                .l(7);
+        StringBuilder str = new StringBuilder("text");
+        Object[] testArr = {str.toString(), true, (byte) 1, (short) 2, '3', 4, 5.0f, 6.0, 7L};
+        Object[] resetedArray = {"",false, (byte) 0, (short) 0, '\0', 0, 0f, 0.0 , 0L};
+        assertEquals(testArr, mt.makeArray());
         mt.reset();
-        assertEquals("!net.openhft.chronicle.wire.MyTypes {\n" +
-                "  text: \"\",\n" +
-                "  flag: false,\n" +
-                "  b: 0,\n" +
-                "  s: 0,\n" +
-                "  ch: \"\\0\",\n" +
-                "  i: 0,\n" +
-                "  f: 0.0,\n" +
-                "  d: 0.0,\n" +
-                "  l: 0\n" +
-                "}\n", mt.toString());
+        assertEquals(resetedArray,mt.makeArray());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/wire/MyTypes.java
+++ b/src/test/java/net/openhft/chronicle/wire/MyTypes.java
@@ -121,4 +121,11 @@ class MyTypes extends SelfDescribingMarshallable {
             return ordinal();
         }
     }
+
+    public Object[] makeArray() {
+
+        Object[] array = {text().toString(), flag(), b(), s(), ch(), i(), f(), d(), l()};
+
+        return array;
+    }
 }


### PR DESCRIPTION
The test `net.openhft.chronicle.wire.MarshallableTest.testReset` failed with NonDex shuffling (though it passed the regular test-compile) because it had an assertion that compared a hard-coded string against a class structure whose order was nondeterministic, and therefore the order of the structure did not exactly match that of the string most of the time. For example:

	[ERROR] Failures: 
	[ERROR]   MarshallableTest.testReset:159 expected:<...le.wire.MyTypes {
	  [text: text,
	  flag: true,
	  b: 1,
	  s: 2,
	  ch: "3",
	  i: 4,
	  f: 5.0,
	  d: 6.0,
	  l: 7]
	}
	> but was:<...le.wire.MyTypes {
	  [s: 2,
	  text: text,
	  flag: true,
	  l: 7,
	  ch: "3",
	  d: 6.0,
	  i: 4,
	  f: 5.0,
	  b: 1]
	}

To solve this I created two test arrays with the values that were needed to compare against (I took those values from the hard-coded string) and then created a method in `MyType.java` that stores the values of the class attributes in an object array in a static way. This allows having all structures in the correct order without having to meddle with the actual values and details of the class attributes, which in exchange allows for the proper execution of assertEquals.

As a side note, I want to add that the `text()` element from `MyType` couldn't be compared against the other StringBuilder predefined in the test array because StringBuilder doesn't override Object's `equals()` function. My solution to this was to convert both StringBuilder objects to strings.